### PR TITLE
Updates updateCheck event check

### DIFF
--- a/_js/rwd-table.js
+++ b/_js/rwd-table.js
@@ -64,10 +64,10 @@
 	            })
 	            .bind("updateCheck", function(){
 	               if ( th.css("display") == "table-cell" || th.css("display") == "inline" ) {
-	                  $(this).attr("checked", true);
+	                  $(this).prop("checked", true);
 	               }
 	               else {
-	                  $(this).attr("checked", false);
+	                  $(this).prop("checked", false);
 	               }
 	            })
 	            .trigger("updateCheck");  


### PR DESCRIPTION
As of jQuery 1.6 `.prop()` should be used when setting the checked property. This fix will allow this code to be usable by newer versions of jQuery.
